### PR TITLE
Заменен deprecated метод в JivoSdk.m

### DIFF
--- a/iOS/JivoSdk.m
+++ b/iOS/JivoSdk.m
@@ -172,7 +172,7 @@ static Class hackishFixClass = Nil;
 
 
 - (NSString *)decodeString:(NSString *)encodedString {
-    NSString *decodedString = [encodedString stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
+    NSString *decodedString = [encodedString stringByRemovingPercentEncoding];
 
     return decodedString;
 }


### PR DESCRIPTION
Заменен метод, который являлся deprecated, на его новый аналог. С кодировкой проблем не возникает, так как utf8 в новом методе по умолчанию.